### PR TITLE
add slave status metric

### DIFF
--- a/ActiveMQ-classic/5.18.3-jdbc/jmx_dockerImage/assets/config.yaml
+++ b/ActiveMQ-classic/5.18.3-jdbc/jmx_dockerImage/assets/config.yaml
@@ -37,3 +37,7 @@ rules:
   name: activemq_$2_usage_ratio
   type: GAUGE
   valueFactor: 0.01
+
+- pattern: org.apache.activemq<type=Broker, brokerName=(\S*)><>(.*)Slave
+  name: activemq_$2_slave
+  type: GAUGE


### PR DESCRIPTION
this change return host:port/metrics value for slave status

```
# HELP activemq_slave Slave broker. org.apache.activemq:name=null,type=Broker,attribute=Slave
# TYPE activemq_slave gauge
activemq_slave 1.0
```